### PR TITLE
Feat/gh init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # repo-scaffold
 
-[![PyPI version](https://badge.fury.io/py/repo-scaffold.svg)](https://badge.fury.io/py/repo-scaffold)
+[![PyPI](https://img.shields.io/pypi/v/repo-scaffold.svg)](https://pypi.org/project/repo-scaffold/)
 [![Python Version](https://img.shields.io/pypi/pyversions/repo-scaffold.svg)](https://pypi.org/project/repo-scaffold/)
+[![CI](https://github.com/ShawnDen-coder/repo-scaffold/actions/workflows/ci-tests.yaml/badge.svg)](https://github.com/ShawnDen-coder/repo-scaffold/actions/workflows/ci-tests.yaml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 A modern project scaffolding tool that helps you quickly create standardized project structures with best practices.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,14 @@ repo-scaffold create python --no-input -o ./my-projects
 
 # Create a uv workspace monorepo
 repo-scaffold create uv-workspace -o ./my-projects
+
+# Push a generated project to GitHub: create the repo, set CI secrets,
+# push the initial commit. Reads GITHUB_TOKEN from the environment.
+export GITHUB_TOKEN=ghp_...
+repo-scaffold gh-init ./my-projects/my-python-project
 ```
+
+See the [GitHub bootstrap docs](https://shawnden-coder.github.io/repo-scaffold/templates/gh-init/) for the full flag list and the secrets/variables `gh-init` knows how to set.
 
 ## Available Templates
 

--- a/docs/templates/gh-init.md
+++ b/docs/templates/gh-init.md
@@ -1,0 +1,103 @@
+# `repo-scaffold gh-init`
+
+Bootstrap a GitHub repository for a project that you've already generated with `repo-scaffold create`. The command:
+
+1. Creates the repository on GitHub (or finds it, with `--allow-existing`).
+2. Sets the Actions secrets and variables that the generated workflows expect.
+3. Initializes git locally (if needed), commits, and pushes the initial revision.
+
+After the first `docs-deploy` workflow run, you flip Pages to `gh-pages / (root)` once in **Settings → Pages**. That's the only manual step left.
+
+## Prerequisites
+
+- A GitHub personal access token in the `GITHUB_TOKEN` environment variable.
+  - **Public repo**: `public_repo` scope is enough.
+  - **Private repo**: `repo` scope.
+  - Generate one at <https://github.com/settings/tokens>.
+- `git` on `PATH` (only needed when pushing).
+
+`gh-init` does **not** read `gh auth token`. Set `GITHUB_TOKEN` explicitly so behavior is the same in CI and locally.
+
+## Usage
+
+```bash
+# Generate a project, then push it to your account.
+repo-scaffold create python --no-input -o ./projects
+export GITHUB_TOKEN=ghp_...
+repo-scaffold gh-init ./projects/my-python-project
+```
+
+The command will print a summary, prompt you to confirm, then create the repo and push.
+
+### Common flags
+
+| Flag | Behavior |
+| --- | --- |
+| `--owner <user-or-org>` | Push to an organization instead of your own account. |
+| `--name <repo>` | Override the repository name (default: `pyproject.toml` `project.name`). |
+| `--description <text>` | Override the repository description. |
+| `--private` / `--public` | Repository visibility (default: public). |
+| `--default-branch <name>` | Override the default branch (default: current local git branch or `master`). |
+| `--allow-existing` | Don't fail if the repo already exists; refresh secrets/variables. |
+| `--no-push` | Skip git init and push — only configure GitHub. |
+| `--force-push` | `git push --force` the initial commit (if the remote already has commits). |
+| `--no-input` | Don't prompt; missing optional secrets are skipped. |
+
+### Examples
+
+Create a private org repo non-interactively:
+
+```bash
+GITHUB_TOKEN=... \
+PYPI_SERVER_USERNAME=... \
+PYPI_SERVER_PASSWORD=... \
+repo-scaffold gh-init ./projects/my-private-tool \
+  --owner my-org --private --no-input
+```
+
+Re-run after rotating a secret (the repo already exists, you just want to refresh values):
+
+```bash
+repo-scaffold gh-init ./projects/my-tool --allow-existing --no-push --no-input
+```
+
+## Where the secret values come from
+
+`gh-init` looks for each value in this order. The first non-empty source wins; an empty result is **dropped**, never written as an empty secret.
+
+1. The current process environment (`GITHUB_TOKEN`, `PYPI_TOKEN`, etc.).
+2. A `.env` file in the project directory (simple `KEY=VALUE` lines, comments with `#`).
+3. Interactive prompts (skipped under `--no-input`).
+4. Defaults from the project's `pyproject.toml` for the repo name and description.
+
+The default keys configured in the generated workflows are:
+
+| Kind | Name | Used by |
+| --- | --- | --- |
+| Secret | `PERSONAL_ACCESS_TOKEN` | `version-bump` (push tags), `package-release` (GitHub Release), `container-release` (GHCR) |
+| Secret | `PYPI_TOKEN` | `package-release` → public PyPI |
+| Secret | `PYPI_SERVER_USERNAME` | `package-release` → private PyPI server |
+| Secret | `PYPI_SERVER_PASSWORD` | `package-release` → private PyPI server |
+| Variable | `PUBLISH_TO_PUBLIC_PYPI` | gates the public PyPI publish job (`'true'` to enable) |
+
+Anything you skip can be added later under **Settings → Secrets and variables → Actions**.
+
+## What the command actually does
+
+1. Reads `GITHUB_TOKEN`, calls `GET /user` to verify the token early.
+2. Calls `POST /user/repos` (or `POST /orgs/{owner}/repos`) with `auto_init=false`. If the repo exists and `--allow-existing` is set, it falls back to `GET /repos/{owner}/{name}`.
+3. For each non-empty secret, calls the Actions secrets API (PUT, so existing secrets are overwritten).
+4. For each non-empty variable, calls the Actions variables API. If the variable already exists, the call falls back to an `edit`.
+5. Unless `--no-push` is set: runs `git init` if needed, stages every tracked and untracked file, creates a `chore: initial commit from repo-scaffold` commit (only if HEAD doesn't yet exist), renames the current branch, sets `origin`, and pushes.
+
+## Manual step: enable Pages
+
+The docs workflow uses `mkdocs gh-deploy --force` to push static HTML to a `gh-pages` branch. That branch doesn't exist until the first deploy runs, and GitHub's Pages API rejects enabling Pages with a non-existent source — so `gh-init` doesn't try.
+
+After the first `docs-deploy` workflow run completes (triggered by your first version tag, e.g. `0.1.0`):
+
+1. Open the new repo on GitHub.
+2. Go to **Settings → Pages**.
+3. Under **Build and deployment**, set **Source: Deploy from a branch**.
+4. Pick the `gh-pages` branch and `/ (root)` as the path.
+5. Save. The site appears at `https://<owner>.github.io/<repo>` within a minute.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
       - python: templates/python.md
       - uv-workspace: templates/uv-workspace.md
       - CI/CD pipeline: templates/ci-cd.md
+      - GitHub bootstrap: templates/gh-init.md
   - API Reference: reference/
 plugins:
   - search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "cookiecutter>=2.6.0",
     "click>=8.1.8",
     "ruff>=0.9.6",
+    "PyGithub>=2.4",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,26 @@
 [project]
 name = "repo-scaffold"
 version = "0.15.1"
-description = "shawn deng repo temple project"
+description = "A modern project scaffolding tool that helps you quickly create standardized project structures with best practices."
 authors = [
     {name = "shawndeng", email = "shawndeng1109@qq.com"}
 ]
 license = "MIT"
 readme = "README.md"
 requires-python = ">=3.12"
+keywords = ["cookiecutter", "scaffold", "template", "uv", "python"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+]
 dependencies = [
     "cookiecutter>=2.6.0",
     "click>=8.1.8",

--- a/repo_scaffold/cli.py
+++ b/repo_scaffold/cli.py
@@ -33,6 +33,10 @@ from typing import Any
 import click
 from cookiecutter.main import cookiecutter
 
+from repo_scaffold.github_init import GhInitClient
+from repo_scaffold.github_init import build_config
+from repo_scaffold.github_init import init_repository
+
 
 def get_package_path(relative_path: str) -> str:
     """Get absolute path to a resource in the package.
@@ -191,6 +195,132 @@ def create(template: str, output_dir: Path, no_input: bool, no_install: bool):
         no_input=no_input,  # 根据用户选择决定是否启用交互式输入
         extra_context={"install_after_generate": "no" if no_install else "yes"},
     )
+
+
+@cli.command("gh-init")
+@click.argument(
+    "project_path",
+    type=click.Path(file_okay=False, dir_okay=True, exists=True, path_type=Path),
+)
+@click.option("--owner", help="GitHub user or org (default: authenticated user).")
+@click.option("--name", help="Repository name (default: from pyproject.toml).")
+@click.option(
+    "--description",
+    help="Repository description (default: from pyproject.toml).",
+)
+@click.option(
+    "--private/--public",
+    default=False,
+    help="Repository visibility (default: public).",
+)
+@click.option(
+    "--default-branch",
+    "default_branch",
+    help="Default branch name (default: current local git branch or 'master').",
+)
+@click.option(
+    "--allow-existing",
+    is_flag=True,
+    help="Don't fail if the repository already exists; refresh secrets/variables.",
+)
+@click.option("--no-push", is_flag=True, help="Skip git init and push.")
+@click.option(
+    "--force-push",
+    is_flag=True,
+    help="Use --force when pushing the initial commit.",
+)
+@click.option(
+    "--no-input",
+    is_flag=True,
+    help="Don't prompt; missing optional secrets are skipped.",
+)
+def gh_init(
+    project_path: Path,
+    owner: str | None,
+    name: str | None,
+    description: str | None,
+    private: bool,
+    default_branch: str | None,
+    allow_existing: bool,
+    no_push: bool,
+    force_push: bool,
+    no_input: bool,
+):
+    """Initialize a GitHub repository for an already-generated project.
+
+    Creates the repository on GitHub, sets the CI secrets and variables that
+    the generated workflows expect, and (unless --no-push is given) pushes the
+    project's initial commit to the new repo.
+
+    Authentication: reads the ``GITHUB_TOKEN`` environment variable. The token
+    must have ``repo`` scope for private repos, ``public_repo`` for public
+    ones.
+    """
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        raise click.ClickException(
+            "GITHUB_TOKEN environment variable is required. "
+            "Generate a personal access token with `repo` scope at "
+            "https://github.com/settings/tokens and export it before running gh-init."
+        )
+
+    prompter = None
+    if not no_input:
+
+        def prompter(key: str, default: str | None) -> str:
+            hide = key.endswith(("_TOKEN", "_PASSWORD"))
+            return click.prompt(
+                f"{key} (Enter to skip)" if default is None else key,
+                default=default if default is not None else "",
+                hide_input=hide,
+                show_default=default is not None,
+            )
+
+    config = build_config(
+        project_path=project_path,
+        owner=owner,
+        name=name,
+        description=description,
+        private=private,
+        default_branch=default_branch,
+        push=not no_push,
+        force_push=force_push,
+        allow_existing=allow_existing,
+        prompter=prompter,
+    )
+
+    click.echo("")
+    click.echo("Will create or update repository:")
+    click.echo(f"  Repo:        {config.owner or '<authenticated user>'}/{config.name}")
+    click.echo(f"  Visibility:  {'private' if config.private else 'public'}")
+    click.echo(f"  Description: {config.description or '(none)'}")
+    click.echo(f"  Branch:      {config.default_branch}")
+    secrets_listed = ", ".join(config.secrets) or "(none)"
+    variables_listed = ", ".join(f"{k}={v}" for k, v in config.variables.items()) or "(none)"
+    click.echo(f"  Secrets:     {secrets_listed}")
+    click.echo(f"  Variables:   {variables_listed}")
+    click.echo(f"  Push:        {'yes' if config.push else 'no'}{' (force)' if config.force_push else ''}")
+    click.echo("")
+
+    if not no_input:
+        click.confirm("Proceed?", default=True, abort=True)
+
+    result = init_repository(config, GhInitClient(token))
+
+    click.echo("")
+    click.echo("✓ Repository ready")
+    click.echo(f"  URL:     {result.html_url}")
+    click.echo(f"  Actions: {result.actions_url}")
+    click.echo(f"  Pages:   {result.pages_url} (after first docs-deploy run)")
+    if result.skipped_secrets:
+        click.echo(f"  Skipped secrets (set later in repo Settings): {', '.join(result.skipped_secrets)}")
+    if result.pushed:
+        click.echo(f"  Pushed initial commit to {config.default_branch}")
+    click.echo("")
+    click.echo("Next steps:")
+    click.echo("  1. Watch the first CI run on the Actions page above.")
+    click.echo("  2. After the first docs-deploy tag run, in repo Settings → Pages set")
+    click.echo("     'Source: Deploy from a branch' to gh-pages / (root).")
 
 
 if __name__ == "__main__":

--- a/repo_scaffold/github_init.py
+++ b/repo_scaffold/github_init.py
@@ -1,0 +1,363 @@
+"""GitHub bootstrap helpers for `repo-scaffold gh-init`.
+
+Three layers:
+
+- ``GhInitConfig`` and ``build_config`` collect the repo metadata, secrets,
+  and variables to apply.
+- ``GhInitClient`` is a thin wrapper around PyGithub so tests can swap the
+  whole client out without monkey-patching the SDK.
+- ``init_repository`` orchestrates the calls and returns the URLs the CLI
+  prints back to the user.
+
+A ``git_push`` helper performs the optional initial commit + push via
+subprocess, no extra dependency on GitPython.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tomllib
+from collections.abc import Callable
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+from typing import Any
+
+from github import Auth
+from github import Github
+from github import GithubException
+from github.Repository import Repository
+
+
+DEFAULT_SECRET_KEYS: tuple[str, ...] = (
+    "PERSONAL_ACCESS_TOKEN",
+    "PYPI_TOKEN",
+    "PYPI_SERVER_USERNAME",
+    "PYPI_SERVER_PASSWORD",
+)
+
+DEFAULT_VARIABLE_KEYS: tuple[str, ...] = ("PUBLISH_TO_PUBLIC_PYPI",)
+
+INITIAL_COMMIT_MESSAGE = "chore: initial commit from repo-scaffold"
+INITIAL_COMMIT_USER = "repo-scaffold"
+INITIAL_COMMIT_EMAIL = "repo-scaffold@users.noreply.github.com"
+
+
+@dataclass
+class GhInitConfig:
+    """Resolved configuration for one ``gh-init`` invocation."""
+
+    project_path: Path
+    name: str
+    description: str
+    private: bool
+    default_branch: str
+    secrets: dict[str, str] = field(default_factory=dict)
+    variables: dict[str, str] = field(default_factory=dict)
+    owner: str | None = None
+    push: bool = True
+    force_push: bool = False
+    allow_existing: bool = False
+
+
+@dataclass
+class GhInitResult:
+    """Outputs surfaced to the CLI after a successful run."""
+
+    html_url: str
+    actions_url: str
+    pages_url: str
+    skipped_secrets: list[str]
+    pushed: bool
+
+
+def parse_dotenv(text: str) -> dict[str, str]:
+    """Parse a tiny subset of dotenv syntax: ``KEY=VALUE`` lines, ``#`` comments.
+
+    Quoted values are unquoted. Anything more exotic (export, multiline, command
+    substitution) is intentionally not supported — projects that need that should
+    set real env vars before running gh-init.
+    """
+    result: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        if key:
+            result[key] = value
+    return result
+
+
+def load_pyproject(project_path: Path) -> dict[str, Any]:
+    """Return the ``[project]`` table from the project's ``pyproject.toml``."""
+    pyproject = project_path / "pyproject.toml"
+    if not pyproject.is_file():
+        return {}
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    return data.get("project", {}) or {}
+
+
+def detect_default_branch(project_path: Path) -> str | None:
+    """Return the current local git branch name, or ``None`` if not a git repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_path), "branch", "--show-current"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return None
+    branch = result.stdout.strip()
+    return branch or None
+
+
+def build_config(
+    project_path: Path,
+    *,
+    owner: str | None = None,
+    name: str | None = None,
+    description: str | None = None,
+    private: bool = False,
+    default_branch: str | None = None,
+    push: bool = True,
+    force_push: bool = False,
+    allow_existing: bool = False,
+    extra_env: dict[str, str] | None = None,
+    prompter: Callable[[str, str | None], str] | None = None,
+) -> GhInitConfig:
+    """Resolve a ``GhInitConfig`` from CLI args, environment, ``.env``, and pyproject.
+
+    Precedence per key (highest first): explicit kwarg, ``extra_env`` (used for
+    secrets/variables and for pulling values from ``os.environ`` at the call
+    site), then the project's ``.env`` file, then ``pyproject.toml`` defaults,
+    then ``prompter`` if provided.
+
+    ``prompter`` receives ``(key, default)`` and returns the user's answer, or
+    an empty string to skip. When ``prompter`` is ``None`` (i.e. ``--no-input``)
+    missing optional values are simply dropped.
+    """
+    project_path = project_path.resolve()
+    pyproject = load_pyproject(project_path)
+    dotenv_path = project_path / ".env"
+    dotenv = parse_dotenv(dotenv_path.read_text(encoding="utf-8")) if dotenv_path.is_file() else {}
+    env = extra_env if extra_env is not None else dict(os.environ)
+
+    def from_env(key: str) -> str:
+        return env.get(key) or dotenv.get(key) or ""
+
+    resolved_name = name or pyproject.get("name") or project_path.name
+    resolved_description = description if description is not None else pyproject.get("description") or ""
+    resolved_branch = default_branch or detect_default_branch(project_path) or "master"
+
+    secrets: dict[str, str] = {}
+    skipped: list[str] = []
+    for key in DEFAULT_SECRET_KEYS:
+        value = from_env(key)
+        if not value and prompter is not None:
+            value = prompter(key, None)
+        if value:
+            secrets[key] = value
+        else:
+            skipped.append(key)
+
+    variables: dict[str, str] = {}
+    for key in DEFAULT_VARIABLE_KEYS:
+        value = from_env(key)
+        if not value and prompter is not None:
+            value = prompter(key, "false")
+        if value:
+            variables[key] = value
+
+    config = GhInitConfig(
+        project_path=project_path,
+        name=resolved_name,
+        description=resolved_description,
+        private=private,
+        default_branch=resolved_branch,
+        secrets=secrets,
+        variables=variables,
+        owner=owner,
+        push=push,
+        force_push=force_push,
+        allow_existing=allow_existing,
+    )
+    config._skipped_secrets = skipped  # type: ignore[attr-defined]
+    return config
+
+
+class GhInitClient:
+    """Tiny PyGithub wrapper that orchestrator and tests both consume."""
+
+    def __init__(self, token: str):
+        """Construct a client backed by the given personal access token."""
+        self._gh = Github(auth=Auth.Token(token))
+        self._user_login: str | None = None
+
+    def authenticated_login(self) -> str:
+        """Return the login of the token's user. Raises on a bad token."""
+        if self._user_login is None:
+            self._user_login = self._gh.get_user().login
+        return self._user_login
+
+    def get_or_create_repo(
+        self,
+        owner: str | None,
+        name: str,
+        *,
+        description: str,
+        private: bool,
+        allow_existing: bool,
+    ) -> Repository:
+        """Create the repo on the right account, or look it up if already there."""
+        login = self.authenticated_login()
+        target_owner = owner or login
+        try:
+            if not owner or owner == login:
+                user = self._gh.get_user()
+                return user.create_repo(
+                    name=name,
+                    description=description or "",
+                    private=private,
+                    auto_init=False,
+                )
+            org = self._gh.get_organization(owner)
+            return org.create_repo(
+                name=name,
+                description=description or "",
+                private=private,
+                auto_init=False,
+            )
+        except GithubException as exc:
+            if exc.status == 422 and allow_existing:
+                return self._gh.get_repo(f"{target_owner}/{name}")
+            raise
+
+    def set_secret(self, repo: Repository, name: str, value: str) -> None:
+        """Create or replace an Actions secret. ``create_secret`` is PUT-based."""
+        repo.create_secret(name, value)
+
+    def set_variable(self, repo: Repository, name: str, value: str) -> None:
+        """Create an Actions variable, falling back to ``edit`` if it exists."""
+        try:
+            repo.create_variable(name, value)
+        except GithubException as exc:
+            if exc.status in (409, 422):
+                repo.get_variable(name).edit(value=value)
+                return
+            raise
+
+
+def init_repository(config: GhInitConfig, client: GhInitClient) -> GhInitResult:
+    """Apply the config to GitHub and (optionally) push the initial commit."""
+    client.authenticated_login()
+    repo = client.get_or_create_repo(
+        config.owner,
+        config.name,
+        description=config.description,
+        private=config.private,
+        allow_existing=config.allow_existing,
+    )
+    for secret_name, value in config.secrets.items():
+        client.set_secret(repo, secret_name, value)
+    for variable_name, value in config.variables.items():
+        client.set_variable(repo, variable_name, value)
+
+    pushed = False
+    if config.push:
+        git_push(
+            project_path=config.project_path,
+            remote_url=repo.clone_url,
+            branch=config.default_branch,
+            force=config.force_push,
+        )
+        pushed = True
+
+    owner_login = repo.owner.login
+    html_url = repo.html_url
+    actions_url = f"{html_url}/actions"
+    pages_url = f"https://{owner_login}.github.io/{repo.name}"
+    skipped = list(getattr(config, "_skipped_secrets", []))
+    return GhInitResult(
+        html_url=html_url,
+        actions_url=actions_url,
+        pages_url=pages_url,
+        skipped_secrets=skipped,
+        pushed=pushed,
+    )
+
+
+def _git(project_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(project_path), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def git_push(project_path: Path, remote_url: str, branch: str, force: bool) -> None:
+    """Initialize git in ``project_path`` if needed, commit, and push to origin.
+
+    Steps:
+      1. ``git init`` if no ``.git`` directory exists.
+      2. Stage everything and create an initial commit (only when there is no
+         existing HEAD — re-runs against an already-initialized repo skip this).
+      3. Rename the current branch to ``branch``.
+      4. (Re-)add ``origin`` pointing at ``remote_url``.
+      5. Push ``branch`` to ``origin`` with ``-u`` (and optionally ``--force``).
+    """
+    try:
+        if not (project_path / ".git").exists():
+            subprocess.run(["git", "init", str(project_path)], check=True, capture_output=True, text=True)
+
+        head_exists = (
+            subprocess.run(
+                ["git", "-C", str(project_path), "rev-parse", "--verify", "HEAD"],
+                check=False,
+                capture_output=True,
+                text=True,
+            ).returncode
+            == 0
+        )
+
+        if not head_exists:
+            _git(project_path, "add", "-A")
+            _git(
+                project_path,
+                "-c",
+                f"user.name={INITIAL_COMMIT_USER}",
+                "-c",
+                f"user.email={INITIAL_COMMIT_EMAIL}",
+                "commit",
+                "-m",
+                INITIAL_COMMIT_MESSAGE,
+            )
+
+        _git(project_path, "branch", "-M", branch)
+
+        # Best-effort: drop any pre-existing origin so `remote add` always works.
+        subprocess.run(
+            ["git", "-C", str(project_path), "remote", "remove", "origin"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        _git(project_path, "remote", "add", "origin", remote_url)
+
+        push_args = ["push", "-u"]
+        if force:
+            push_args.append("--force")
+        push_args += ["origin", branch]
+        _git(project_path, *push_args)
+    except FileNotFoundError as exc:
+        raise RuntimeError("`git` was not found on PATH; install git before running gh-init.") from exc

--- a/tests/test_github_init.py
+++ b/tests/test_github_init.py
@@ -1,0 +1,373 @@
+"""Unit tests for the gh-init pipeline."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+from github import GithubException
+
+from repo_scaffold import github_init
+from repo_scaffold.cli import cli
+from repo_scaffold.github_init import GhInitClient
+from repo_scaffold.github_init import GhInitConfig
+from repo_scaffold.github_init import build_config
+from repo_scaffold.github_init import git_push
+from repo_scaffold.github_init import init_repository
+from repo_scaffold.github_init import parse_dotenv
+
+
+def _write_pyproject(path: Path, *, name: str, description: str = "") -> None:
+    path.write_text(
+        f'[project]\nname = "{name}"\ndescription = "{description}"\n',
+        encoding="utf-8",
+    )
+
+
+def test_parse_dotenv_handles_quotes_and_comments():
+    """Parse honors quoted values, trims whitespace, and skips comments and bare lines."""
+    text = """
+# comment line
+A=plain
+B="quoted value"
+C='single quoted'
+   D=trimmed
+EMPTY=
+not-a-line-no-equals
+"""
+    assert parse_dotenv(text) == {
+        "A": "plain",
+        "B": "quoted value",
+        "C": "single quoted",
+        "D": "trimmed",
+        "EMPTY": "",
+    }
+
+
+def test_build_config_pulls_defaults_from_pyproject(tmp_path):
+    """Defaults flow from pyproject.toml when nothing is overridden."""
+    _write_pyproject(tmp_path / "pyproject.toml", name="my-pkg", description="hello")
+    config = build_config(tmp_path, extra_env={})
+
+    assert config.name == "my-pkg"
+    assert config.description == "hello"
+    assert config.secrets == {}
+    assert config.variables == {}
+    assert config.default_branch in {"master", "main"}  # detect helper falls through to "master"
+    assert config._skipped_secrets == [
+        "PERSONAL_ACCESS_TOKEN",
+        "PYPI_TOKEN",
+        "PYPI_SERVER_USERNAME",
+        "PYPI_SERVER_PASSWORD",
+    ]
+
+
+def test_build_config_resolves_secrets_from_env_then_dotenv(tmp_path):
+    """Process env wins over .env; missing keys are dropped, not stored as empty."""
+    _write_pyproject(tmp_path / "pyproject.toml", name="x")
+    (tmp_path / ".env").write_text(
+        "PYPI_TOKEN=from-dotenv\nPYPI_SERVER_USERNAME=from-dotenv-user\n",
+        encoding="utf-8",
+    )
+    extra_env = {
+        "PYPI_TOKEN": "from-process-env",
+        "PUBLISH_TO_PUBLIC_PYPI": "true",
+    }
+
+    config = build_config(tmp_path, extra_env=extra_env)
+
+    # Process env wins over .env.
+    assert config.secrets["PYPI_TOKEN"] == "from-process-env"
+    # Falls back to .env when env is absent.
+    assert config.secrets["PYPI_SERVER_USERNAME"] == "from-dotenv-user"
+    # Variables come through the same chain.
+    assert config.variables == {"PUBLISH_TO_PUBLIC_PYPI": "true"}
+    # Missing values are dropped, not stored as empty strings.
+    assert "PERSONAL_ACCESS_TOKEN" not in config.secrets
+
+
+def test_build_config_kwargs_take_precedence(tmp_path):
+    """Explicit kwargs override env, dotenv, and pyproject defaults."""
+    _write_pyproject(tmp_path / "pyproject.toml", name="from-pyproject")
+
+    config = build_config(
+        tmp_path,
+        name="from-kwarg",
+        description="from-kwarg-desc",
+        owner="some-org",
+        private=True,
+        default_branch="main",
+        extra_env={},
+    )
+
+    assert config.name == "from-kwarg"
+    assert config.description == "from-kwarg-desc"
+    assert config.owner == "some-org"
+    assert config.private is True
+    assert config.default_branch == "main"
+
+
+def test_build_config_prompter_fills_missing_values(tmp_path):
+    """The prompter callback supplies values not present in env/dotenv/pyproject."""
+    _write_pyproject(tmp_path / "pyproject.toml", name="x")
+    answers = {"PYPI_TOKEN": "prompted-token", "PUBLISH_TO_PUBLIC_PYPI": "true"}
+
+    def prompter(key: str, default: str | None) -> str:
+        return answers.get(key, "")
+
+    config = build_config(tmp_path, extra_env={}, prompter=prompter)
+
+    assert config.secrets == {"PYPI_TOKEN": "prompted-token"}
+    assert config.variables == {"PUBLISH_TO_PUBLIC_PYPI": "true"}
+
+
+def _make_config(tmp_path: Path, **overrides: Any) -> GhInitConfig:
+    base: dict[str, Any] = {
+        "project_path": tmp_path,
+        "name": "demo",
+        "description": "demo project",
+        "private": False,
+        "default_branch": "master",
+        "secrets": {"PYPI_TOKEN": "token-value", "PERSONAL_ACCESS_TOKEN": "pat-value"},
+        "variables": {"PUBLISH_TO_PUBLIC_PYPI": "true"},
+        "owner": None,
+        "push": False,
+        "force_push": False,
+        "allow_existing": False,
+    }
+    base.update(overrides)
+    return GhInitConfig(**base)
+
+
+def test_init_repository_calls_client_in_order(tmp_path):
+    """Orchestrator calls login, repo creation, then secrets and variables in order."""
+    config = _make_config(tmp_path)
+
+    repo = MagicMock()
+    repo.html_url = "https://github.com/me/demo"
+    repo.name = "demo"
+    repo.owner.login = "me"
+
+    client = MagicMock(spec=GhInitClient)
+    client.authenticated_login.return_value = "me"
+    client.get_or_create_repo.return_value = repo
+
+    result = init_repository(config, client)
+
+    client.authenticated_login.assert_called_once_with()
+    client.get_or_create_repo.assert_called_once_with(
+        None, "demo", description="demo project", private=False, allow_existing=False
+    )
+    # Both secrets are set, in iteration order of the dict.
+    assert client.set_secret.call_args_list == [
+        ((repo, "PYPI_TOKEN", "token-value"), {}),
+        ((repo, "PERSONAL_ACCESS_TOKEN", "pat-value"), {}),
+    ]
+    assert client.set_variable.call_args_list == [((repo, "PUBLISH_TO_PUBLIC_PYPI", "true"), {})]
+    assert result.html_url == "https://github.com/me/demo"
+    assert result.actions_url == "https://github.com/me/demo/actions"
+    assert result.pages_url == "https://me.github.io/demo"
+    assert result.pushed is False
+
+
+def test_init_repository_skips_push_when_disabled(tmp_path, monkeypatch):
+    """git_push is not invoked when ``config.push`` is False."""
+    config = _make_config(tmp_path, push=False)
+    monkeypatch.setattr(github_init, "git_push", MagicMock(side_effect=AssertionError("should not push")))
+
+    repo = MagicMock()
+    repo.html_url = "https://github.com/me/demo"
+    repo.name = "demo"
+    repo.owner.login = "me"
+
+    client = MagicMock(spec=GhInitClient)
+    client.get_or_create_repo.return_value = repo
+
+    init_repository(config, client)
+
+
+def test_init_repository_pushes_when_enabled(tmp_path, monkeypatch):
+    """When push is enabled, git_push is called with the repo's clone URL and branch."""
+    config = _make_config(tmp_path, push=True, force_push=True)
+    pushed = MagicMock()
+    monkeypatch.setattr(github_init, "git_push", pushed)
+
+    repo = MagicMock()
+    repo.clone_url = "https://github.com/me/demo.git"
+    repo.html_url = "https://github.com/me/demo"
+    repo.name = "demo"
+    repo.owner.login = "me"
+
+    client = MagicMock(spec=GhInitClient)
+    client.get_or_create_repo.return_value = repo
+
+    result = init_repository(config, client)
+
+    pushed.assert_called_once_with(
+        project_path=tmp_path,
+        remote_url="https://github.com/me/demo.git",
+        branch="master",
+        force=True,
+    )
+    assert result.pushed is True
+
+
+def test_get_or_create_repo_recovers_when_allow_existing(tmp_path):
+    """A 422 from create_repo falls back to get_repo when allow_existing=True."""
+    client = GhInitClient.__new__(GhInitClient)
+    fake_user = MagicMock()
+    fake_user.create_repo.side_effect = GithubException(status=422, data={"message": "exists"})
+    fake_repo = MagicMock(name="existing-repo")
+
+    fake_gh = MagicMock()
+    fake_gh.get_user.return_value = fake_user
+    fake_gh.get_repo.return_value = fake_repo
+    client._gh = fake_gh
+    client._user_login = "me"
+
+    repo = client.get_or_create_repo(None, "demo", description="", private=False, allow_existing=True)
+    assert repo is fake_repo
+    fake_gh.get_repo.assert_called_once_with("me/demo")
+
+
+def test_get_or_create_repo_reraises_without_allow_existing(tmp_path):
+    """Without allow_existing the 422 propagates so the caller sees the conflict."""
+    client = GhInitClient.__new__(GhInitClient)
+    fake_user = MagicMock()
+    fake_user.create_repo.side_effect = GithubException(status=422, data={"message": "exists"})
+    fake_gh = MagicMock()
+    fake_gh.get_user.return_value = fake_user
+    client._gh = fake_gh
+    client._user_login = "me"
+
+    with pytest.raises(GithubException):
+        client.get_or_create_repo(None, "demo", description="", private=False, allow_existing=False)
+
+
+def test_set_variable_falls_back_to_edit_on_conflict():
+    """A 422/409 from create_variable triggers an edit on the existing variable."""
+    client = GhInitClient.__new__(GhInitClient)
+    repo = MagicMock()
+    repo.create_variable.side_effect = GithubException(status=422, data={"message": "exists"})
+
+    client.set_variable(repo, "PUBLISH_TO_PUBLIC_PYPI", "true")
+
+    repo.create_variable.assert_called_once_with("PUBLISH_TO_PUBLIC_PYPI", "true")
+    repo.get_variable.assert_called_once_with("PUBLISH_TO_PUBLIC_PYPI")
+    repo.get_variable.return_value.edit.assert_called_once_with(value="true")
+
+
+def test_set_variable_reraises_on_other_errors():
+    """Any non-conflict GitHub error propagates instead of being swallowed."""
+    client = GhInitClient.__new__(GhInitClient)
+    repo = MagicMock()
+    repo.create_variable.side_effect = GithubException(status=500, data={"message": "boom"})
+
+    with pytest.raises(GithubException):
+        client.set_variable(repo, "X", "Y")
+
+
+def test_cli_gh_init_requires_token(tmp_path, monkeypatch):
+    """gh-init exits non-zero with a clear message when GITHUB_TOKEN is missing."""
+    _write_pyproject(tmp_path / "pyproject.toml", name="x")
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    result = CliRunner().invoke(cli, ["gh-init", str(tmp_path), "--no-input"])
+
+    assert result.exit_code != 0
+    assert "GITHUB_TOKEN" in result.output
+
+
+def test_cli_gh_init_invokes_orchestrator(tmp_path, monkeypatch):
+    """The CLI builds a config, constructs the client, and prints the result URLs."""
+    _write_pyproject(tmp_path / "pyproject.toml", name="demo", description="d")
+    monkeypatch.setenv("GITHUB_TOKEN", "stub")
+    captured = {}
+
+    class StubClient:
+        def __init__(self, token: str):
+            captured["token"] = token
+
+    def fake_init(config, client):
+        captured["config"] = config
+        captured["client"] = client
+        return github_init.GhInitResult(
+            html_url="https://github.com/me/demo",
+            actions_url="https://github.com/me/demo/actions",
+            pages_url="https://me.github.io/demo",
+            skipped_secrets=["PYPI_TOKEN"],
+            pushed=True,
+        )
+
+    monkeypatch.setattr("repo_scaffold.cli.GhInitClient", StubClient)
+    monkeypatch.setattr("repo_scaffold.cli.init_repository", fake_init)
+
+    result = CliRunner().invoke(
+        cli,
+        ["gh-init", str(tmp_path), "--no-input", "--no-push"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["token"] == "stub"
+    assert captured["config"].name == "demo"
+    assert captured["config"].push is False
+    assert "Repository ready" in result.output
+    assert "Skipped secrets" in result.output
+
+
+def _record_calls(monkeypatch, *, head_exists: bool = False):
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        rc = 0
+        # Probe for HEAD: returncode 1 simulates no commits yet; 0 means HEAD exists.
+        if "rev-parse" in cmd and "HEAD" in cmd:
+            rc = 0 if head_exists else 1
+        return subprocess.CompletedProcess(cmd, rc, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return calls
+
+
+def test_git_push_initializes_and_pushes(tmp_path, monkeypatch):
+    """git_push runs init, add, commit, branch -M, remote add, and push -u in order."""
+    calls = _record_calls(monkeypatch, head_exists=False)
+    git_push(tmp_path, "git@github.com:me/demo.git", branch="master", force=False)
+
+    flat = [" ".join(c) for c in calls]
+    assert any(c.startswith("git init ") for c in flat)
+    assert any(c.endswith("add -A") for c in flat)
+    assert any("commit" in c and INITIAL_COMMIT_MESSAGE in c for c in flat)
+    assert any("branch -M master" in c for c in flat)
+    assert any("remote add origin git@github.com:me/demo.git" in c for c in flat)
+    assert any(c.endswith("push -u origin master") for c in flat)
+
+
+def test_git_push_force_flag_added(tmp_path, monkeypatch):
+    """``--force-push`` adds ``--force`` to the final ``git push`` invocation."""
+    calls = _record_calls(monkeypatch, head_exists=False)
+    git_push(tmp_path, "url", branch="main", force=True)
+
+    flat = [" ".join(c) for c in calls]
+    assert any(c.endswith("push -u --force origin main") for c in flat)
+
+
+def test_git_push_skips_commit_when_head_exists(tmp_path, monkeypatch):
+    """When HEAD already exists, git_push does not stage or commit again."""
+    calls = _record_calls(monkeypatch, head_exists=True)
+    (tmp_path / ".git").mkdir()  # skip git init step
+    git_push(tmp_path, "url", branch="master", force=False)
+
+    # Inspect tokens, not stringified commands, so the "commit" token in
+    # `INITIAL_COMMIT_MESSAGE` doesn't trigger a false positive.
+    assert not any("add" in c and "-A" in c for c in calls)
+    assert not any("commit" in c for c in calls)
+
+
+# Constant under test, kept local to avoid importing internal name into tests.
+INITIAL_COMMIT_MESSAGE = "chore: initial commit from repo-scaffold"

--- a/uv.lock
+++ b/uv.lock
@@ -46,6 +46,63 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "chardet"
 version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -166,6 +223,56 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/79/b7cee656cfb17a7f2c1b9c3cee03dd5d8000ca299ad4038ba64b61a9b044/coverage-7.6.12-cp313-cp313t-win32.whl", hash = "sha256:eb5507795caabd9b2ae3f1adc95f67b1104971c22c624bb354232d65c4fc90b3", size = 212033, upload-time = "2025-02-11T14:46:35.79Z" },
     { url = "https://files.pythonhosted.org/packages/b6/c3/f7aaa3813f1fa9a4228175a7bd368199659d392897e184435a3b66408dd3/coverage-7.6.12-cp313-cp313t-win_amd64.whl", hash = "sha256:f60a297c3987c6c02ffb29effc70eadcbb412fe76947d394a1091a3615948e2f", size = 213240, upload-time = "2025-02-11T14:46:38.119Z" },
     { url = "https://files.pythonhosted.org/packages/fb/b2/f655700e1024dec98b10ebaafd0cedbc25e40e4abe62a3c8e2ceef4f8f0a/coverage-7.6.12-py3-none-any.whl", hash = "sha256:eb8668cfbc279a536c633137deeb9435d2962caec279c3f8cf8b91fff6ff8953", size = 200552, upload-time = "2025-02-11T14:47:01.999Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
@@ -484,12 +591,51 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygithub"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "pynacl" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/c3/8465a311197e16cf5ab68789fe689535e90f6b61ab524cc32a39e67237ae/pygithub-2.9.1.tar.gz", hash = "sha256:59771d7ff63d54d427be2e7d0dad2208dfffc2b0a045fec959263787739b611c", size = 2594989, upload-time = "2026-04-14T07:26:13.622Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/aa/81a5506f089a26338bff17535e4339b3b22049ebd1bcdeff756c4d7a7559/pygithub-2.9.1-py3-none-any.whl", hash = "sha256:2ec78fca30092d51a42d76f4ddb02131b6f0c666a35dfdf364cf302cdda115b9", size = 449710, upload-time = "2026-04-14T07:26:12.382Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -503,6 +649,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/44/e6de2fdc880ad0ec7547ca2e087212be815efbc9a425a8d5ba9ede602cbb/pymdown_extensions-10.14.3.tar.gz", hash = "sha256:41e576ce3f5d650be59e900e4ceff231e0aed2a88cf30acaee41e02f063a061b", size = 846846, upload-time = "2025-02-01T15:43:15.42Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/f5/b9e2a42aa8f9e34d52d66de87941ecd236570c7ed2e87775ed23bbe4e224/pymdown_extensions-10.14.3-py3-none-any.whl", hash = "sha256:05e0bee73d64b9c71a4ae17c72abc2f700e8bc8403755a00580b49a4e9f189e9", size = 264467, upload-time = "2025-02-01T15:43:13.995Z" },
+]
+
+[[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064, upload-time = "2026-01-01T17:31:57.264Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370, upload-time = "2026-01-01T17:31:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304, upload-time = "2026-01-01T17:32:01.162Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871, upload-time = "2026-01-01T17:32:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356, upload-time = "2026-01-01T17:32:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814, upload-time = "2026-01-01T17:32:06.078Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742, upload-time = "2026-01-01T17:32:07.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714, upload-time = "2026-01-01T17:32:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257, upload-time = "2026-01-01T17:32:11.026Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319, upload-time = "2026-01-01T17:32:12.46Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044, upload-time = "2026-01-01T17:32:13.781Z" },
+    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740, upload-time = "2026-01-01T17:32:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
 ]
 
 [[package]]
@@ -652,6 +833,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "cookiecutter" },
+    { name = "pygithub" },
     { name = "ruff" },
 ]
 
@@ -681,6 +863,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.3" },
     { name = "mkdocstrings", marker = "extra == 'docs'", specifier = ">=0.24.0" },
     { name = "mkdocstrings-python", marker = "extra == 'docs'", specifier = ">=1.7.5" },
+    { name = "pygithub", specifier = ">=2.4" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.4" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
@@ -767,6 +950,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/60/47d92293d9bc521cd2301e423a358abfac0ad409b3a1606d8fbae1321961/types_python_dateutil-2.9.0.20241206.tar.gz", hash = "sha256:18f493414c26ffba692a72369fea7a154c502646301ebfe3d56a04b3767284cb", size = 13802, upload-time = "2024-12-06T02:56:41.019Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/b3/ca41df24db5eb99b00d97f89d7674a90cb6b3134c52fb8121b6d8d30f15c/types_python_dateutil-2.9.0.20241206-py3-none-any.whl", hash = "sha256:e248a4bc70a486d3e3ec84d0dc30eec3a5f979d6e7ee4123ae043eedbb987f53", size = 14384, upload-time = "2024-12-06T02:56:39.412Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request adds a new `gh-init` command to `repo-scaffold`, enabling users to bootstrap and push generated projects to GitHub with CI/CD secrets and variables set up automatically. It also improves project metadata, documentation, and the CLI interface.

**New GitHub bootstrap feature:**

* Added a `gh-init` CLI command to automate GitHub repository creation, secret/variable setup, and initial commit push for generated projects. The command supports various flags for customization and reads `GITHUB_TOKEN` from the environment.
* Implemented the supporting logic and imports for the new GitHub bootstrap feature in `repo_scaffold/cli.py`.

**Documentation updates:**

* Added comprehensive documentation for the new `gh-init` command in `docs/templates/gh-init.md`, including usage, flags, prerequisites, and workflow details.
* Updated `README.md` with badges for PyPI, CI, and Ruff, and added instructions and links for using the new GitHub bootstrap feature. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R7) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49-R57)
* Added the new "GitHub bootstrap" documentation page to the navigation in `mkdocs.yml`.

**Project metadata improvements:**

* Updated `pyproject.toml` with a more descriptive summary, relevant keywords, PyPI classifiers, and added `PyGithub` as a dependency to support GitHub integration.