### PR TITLE
fix(ci): push bump commit + tag from cog.toml post_bump_hooks

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -8,7 +8,7 @@ pre_bump_hooks = [
     "uv lock --no-upgrade",
 ]
 
-post_bump_hooks = []
+post_bump_hooks = ["git push --follow-tags"]
 
 [changelog]
 path = "CHANGELOG.md"

--- a/docs/templates/ci-cd.md
+++ b/docs/templates/ci-cd.md
@@ -92,7 +92,7 @@ This catches Dockerfile / dependency regressions on PRs, before they would other
 │   - run pre_bump_hooks (uv version, uv lock)    │
 │   - update CHANGELOG.md                         │
 │   - commit + tag (cog-bot identity)             │
-│   - push commit + tag                           │
+│   - run post_bump_hooks → git push --follow-tags│
 └─────────────────────────────────────────────────┘
 ```
 
@@ -108,7 +108,11 @@ Cocogitto's own bump commits are prefixed with `chore(version):`, so the workflo
 
 **Why a PAT, not the default token**
 
-Checkout uses `token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}`. When cocogitto pushes the bump commit and tag, that push needs to come from a token GitHub recognizes as "real activity" — pushes made with the default `GITHUB_TOKEN` are explicitly prevented from triggering downstream workflows, which would mean the `X.Y.Z` tag push never fires `package-release` or `docs-deploy`.
+Checkout uses `token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}`. When cocogitto's `post_bump_hooks` runs `git push --follow-tags` it reuses the auth that checkout configured, so the push must come from a token GitHub recognizes as "real activity" — pushes made with the default `GITHUB_TOKEN` are explicitly prevented from triggering downstream workflows, which would mean the `X.Y.Z` tag push never fires `package-release` or `docs-deploy`.
+
+**Push is a cog hook, not a workflow step**
+
+`cocogitto-action` only runs `cog bump --auto` locally on the runner — creating the bump commit and tag — and does **not** push. Following the [Cocogitto bump guide](https://docs.cocogitto.io/guide/bump.html), `cog.toml` declares `post_bump_hooks = ["git push --follow-tags"]` so the same `cog bump` invocation handles the push whether you run it locally or in CI. The workflow itself doesn't have a separate push step.
 
 **Concurrency**
 

--- a/repo_scaffold/templates/template-python/{{cookiecutter.project_slug}}/cog.toml
+++ b/repo_scaffold/templates/template-python/{{cookiecutter.project_slug}}/cog.toml
@@ -8,7 +8,7 @@ pre_bump_hooks = [
     "uv lock --no-upgrade",
 ]
 
-post_bump_hooks = []
+post_bump_hooks = ["git push --follow-tags"]
 
 [changelog]
 path = "CHANGELOG.md"

--- a/repo_scaffold/templates/template-uv-workspace/{{cookiecutter.project_slug}}/cog.toml
+++ b/repo_scaffold/templates/template-uv-workspace/{{cookiecutter.project_slug}}/cog.toml
@@ -7,11 +7,9 @@ generate_mono_repository_global_tag = true
 generate_mono_repository_package_tags = true
 monorepo_version_separator = "-"
 
-post_bump_hooks = [
-    "uv lock --no-upgrade",
-    "git add uv.lock",
-    "git commit --amend --no-edit",
-]
+pre_bump_hooks = ["uv lock --no-upgrade"]
+
+post_bump_hooks = ["git push --follow-tags"]
 
 [changelog]
 path = "CHANGELOG.md"


### PR DESCRIPTION
`cocogitto-action@v3` runs `cog bump --auto` locally on the runner but does not push — so the bump commit and tag created on 0.16.0's CI run never reached origin. The cocogitto bump guide recommends using `post_bump_hooks` to push, which keeps local `cog bump` runs and CI in sync.

Add `post_bump_hooks = ["git push --follow-tags"]` to all three cog.toml files (root + both templates).

For the uv-workspace template, also move `uv lock --no-upgrade` from post_bump_hooks (where it required a fragile `git commit --amend` to fold the lockfile into the just-tagged bump commit) to the global `pre_bump_hooks`, so the lockfile is staged before cog creates its commit and tag in the first place.

Update the CI/CD docs to reflect that push is a cog hook, not a separate workflow step.