### PR TITLE
chore(ci): push cocogitto tags explicitly

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -8,7 +8,10 @@ pre_bump_hooks = [
     "uv lock --no-upgrade",
 ]
 
-post_bump_hooks = ["git push --follow-tags"]
+post_bump_hooks = [
+    "git push",
+    "git push origin {{version}}",
+]
 
 [changelog]
 path = "CHANGELOG.md"

--- a/repo_scaffold/templates/template-python/{{cookiecutter.project_slug}}/cog.toml
+++ b/repo_scaffold/templates/template-python/{{cookiecutter.project_slug}}/cog.toml
@@ -7,7 +7,10 @@ pre_bump_hooks = [
     "uv lock --no-upgrade",
 ]
 
-post_bump_hooks = ["git push --follow-tags"]
+post_bump_hooks = [
+    "git push",
+    "git push origin {% raw %}{{version}}{% endraw %}",
+]
 
 [changelog]
 path = "CHANGELOG.md"

--- a/repo_scaffold/templates/template-uv-workspace/{{cookiecutter.project_slug}}/cog.toml
+++ b/repo_scaffold/templates/template-uv-workspace/{{cookiecutter.project_slug}}/cog.toml
@@ -8,7 +8,10 @@ monorepo_version_separator = "-"
 
 pre_bump_hooks = ["uv lock --no-upgrade"]
 
-post_bump_hooks = ["git push --follow-tags"]
+post_bump_hooks = [
+    "git push",
+    "git push --tags",
+]
 
 [changelog]
 path = "CHANGELOG.md"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -106,9 +106,13 @@ def _render_template(
 def _assert_no_unrendered_markers(project_dir: Path) -> None:
     markers = ("{{ cookiecutter", "{{cookiecutter", "{% raw %}", "{% endraw %}")
     for path in project_dir.rglob("*"):
-        if path.is_file():
+        if not path.is_file() or "__pycache__" in path.parts:
+            continue
+        try:
             text = path.read_text(encoding="utf-8")
-            assert not any(marker in text for marker in markers), path
+        except UnicodeDecodeError:
+            continue
+        assert not any(marker in text for marker in markers), path
 
 
 def _assert_no_task_runner_references(project_dir: Path) -> None:
@@ -170,6 +174,17 @@ def _assert_cog_does_not_require_existing_tag(project_dir: Path) -> None:
     assert "from_latest_tag" not in cog_config.read_text(encoding="utf-8")
 
 
+def _assert_cog_pushes_tags_explicitly(project_dir: Path) -> None:
+    cog_config = project_dir / "cog.toml"
+    if not cog_config.exists():
+        return
+
+    text = cog_config.read_text(encoding="utf-8")
+    assert '"git push"' in text
+    assert "git push origin " in text or '"git push --tags"' in text
+    assert "git push --follow-tags" not in text
+
+
 def _assert_static_project_valid(project_dir: Path) -> None:
     _assert_no_task_runner_references(project_dir)
     _assert_no_unrendered_markers(project_dir)
@@ -178,6 +193,7 @@ def _assert_static_project_valid(project_dir: Path) -> None:
     _assert_workflows_have_github_expressions(project_dir)
     _assert_version_bump_avoids_self_trigger(project_dir)
     _assert_cog_does_not_require_existing_tag(project_dir)
+    _assert_cog_pushes_tags_explicitly(project_dir)
 
 
 def test_template_python_renders_with_justfile(tmp_path):


### PR DESCRIPTION
This pull request updates the version bump hooks in `cog.toml` files across project templates to improve how git pushes and tags are handled, and adds test coverage to ensure these changes are enforced. The changes also make the test suite more robust by skipping non-text and cache files when checking for unrendered template markers.

**Version bump hook improvements:**

* Updated `post_bump_hooks` in the main `cog.toml` to split the push and tag commands, now running `git push` and `git push origin {{version}}` separately instead of `git push --follow-tags`.
* Updated `post_bump_hooks` in the Python template's `cog.toml` to use both `git push` and `git push origin {{version}}`, ensuring tags are pushed explicitly and template variables are handled correctly.
* Updated `post_bump_hooks` in the UV workspace template's `cog.toml` to use both `git push` and `git push --tags`, ensuring tags are pushed explicitly.

**Test improvements:**

* Added `_assert_cog_pushes_tags_explicitly` to verify that the new explicit push commands are present and the old `git push --follow-tags` is not used in `cog.toml` files. This check is now part of the static project validation. [[1]](diffhunk://#diff-fb9a6b303a1ee9aee3a11676087245ab2f2f20fc350d1b0fc62dc070c4e9d4c9R177-R187) [[2]](diffhunk://#diff-fb9a6b303a1ee9aee3a11676087245ab2f2f20fc350d1b0fc62dc070c4e9d4c9R196)
* Improved `_assert_no_unrendered_markers` to skip binary and cache files, preventing false positives and errors when scanning for unrendered template markers.