### PR TITLE
fix(gh-init): authenticate git push with the bootstrap token

### DIFF
--- a/repo_scaffold/github_init/__init__.py
+++ b/repo_scaffold/github_init/__init__.py
@@ -18,6 +18,8 @@ extra dependency on GitPython.
 
 from __future__ import annotations
 
+import base64
+import os
 import subprocess
 from pathlib import Path
 
@@ -69,17 +71,31 @@ def _github_error_message(exc: GithubException) -> str:
     return str(data["message"]) if isinstance(data, dict) and "message" in data else str(exc)
 
 
-def deploy_docs(project_path: Path) -> None:
+def deploy_docs(project_path: Path, *, token: str | None = None) -> None:
     """Build the MkDocs site and push it to the ``gh-pages`` branch.
 
     Runs the project's ``deploy-gh-pages`` just recipe (``mkdocs gh-deploy
     --force``), which builds with the right docs dependency group/extra, writes
     ``.nojekyll``, and pushes to ``origin``. Raises ``RuntimeError`` on failure
     so the orchestrator can surface it without aborting the whole bootstrap.
+
+    ``mkdocs gh-deploy`` shells out to ``git push`` itself, so when ``token`` is
+    given the PAT is injected via ``GIT_CONFIG_PARAMETERS`` (an
+    ``http.extraheader`` ``Authorization: Basic`` header) and the terminal
+    prompt is disabled. This authenticates the push non-interactively without
+    ever writing the token to ``.git/config``.
     """
     cmd = ["uvx", "--from", "rust-just", "just", "deploy-gh-pages"]
+    env = None
+    if token:
+        creds = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+        env = {
+            **os.environ,
+            "GIT_CONFIG_PARAMETERS": f"'http.extraheader=Authorization: Basic {creds}'",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
     try:
-        subprocess.run(cmd, cwd=str(project_path), check=True, capture_output=True, text=True)
+        subprocess.run(cmd, cwd=str(project_path), check=True, capture_output=True, text=True, env=env)
     except FileNotFoundError as exc:
         raise RuntimeError("`uvx` was not found on PATH; install uv before running gh-init.") from exc
     except subprocess.CalledProcessError as exc:
@@ -96,7 +112,14 @@ def _git(project_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def git_push(project_path: Path, remote_url: str, branch: str, force: bool) -> None:
+def git_push(
+    project_path: Path,
+    remote_url: str,
+    branch: str,
+    force: bool,
+    *,
+    token: str | None = None,
+) -> None:
     """Initialize git in ``project_path`` if needed, commit, and push to origin.
 
     Steps:
@@ -106,6 +129,13 @@ def git_push(project_path: Path, remote_url: str, branch: str, force: bool) -> N
       3. Rename the current branch to ``branch``.
       4. (Re-)add ``origin`` pointing at ``remote_url``.
       5. Push ``branch`` to ``origin`` with ``-u`` (and optionally ``--force``).
+
+    ``remote_url`` is the repo's plain HTTPS clone URL (no embedded creds), so a
+    non-interactive push has no way to authenticate: there is no TTY under
+    ``capture_output`` and no credential helper is assumed. When ``token`` is
+    given, the PAT is sent as an ``Authorization: Basic`` header via a one-shot
+    ``-c http.extraheader=...`` so the push authenticates without the token ever
+    being written to ``.git/config``.
     """
     try:
         if not (project_path / ".git").exists():
@@ -145,7 +175,11 @@ def git_push(project_path: Path, remote_url: str, branch: str, force: bool) -> N
         )
         _git(project_path, "remote", "add", "origin", remote_url)
 
-        push_args = ["push", "-u"]
+        push_args: list[str] = []
+        if token:
+            creds = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+            push_args += ["-c", f"http.extraheader=Authorization: Basic {creds}"]
+        push_args += ["push", "-u"]
         if force:
             push_args.append("--force")
         push_args += ["origin", branch]
@@ -176,6 +210,7 @@ def init_repository(config: GhInitConfig, client: GhInitClient) -> GhInitResult:
             remote_url=repo.clone_url,
             branch=config.default_branch,
             force=config.force_push,
+            token=client.token,
         )
         pushed = True
 
@@ -195,7 +230,7 @@ def init_repository(config: GhInitConfig, client: GhInitClient) -> GhInitResult:
     has_docs = (config.project_path / "mkdocs.yml").is_file()
     if config.setup_pages and pushed and has_docs:
         try:
-            deploy_docs(config.project_path)
+            deploy_docs(config.project_path, token=client.token)
             client.enable_pages(repo, PAGES_BRANCH)
             pages_configured = True
             client.set_homepage(repo, pages_url)

--- a/repo_scaffold/github_init/client.py
+++ b/repo_scaffold/github_init/client.py
@@ -20,6 +20,18 @@ class GhInitClient:
         """Construct a client backed by the given personal access token."""
         self._gh = Github(auth=Auth.Token(token))
         self._user_login: str | None = None
+        self._token = token
+
+    @property
+    def token(self) -> str:
+        """The personal access token this client authenticates with.
+
+        Exposed so the orchestrator can feed it to the non-interactive
+        ``git push`` / ``mkdocs gh-deploy`` subprocesses (see ``git_push`` and
+        ``deploy_docs``), which need it to authenticate an HTTPS remote that has
+        no credential helper and no TTY.
+        """
+        return self._token
 
     def authenticated_login(self) -> str:
         """Return the login of the token's user. Raises on a bad token."""

--- a/tests/test_github_init.py
+++ b/tests/test_github_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -266,6 +267,7 @@ def test_init_repository_pushes_when_enabled(tmp_path, monkeypatch):
         remote_url="https://github.com/me/demo.git",
         branch="master",
         force=True,
+        token=client.token,
     )
     assert result.pushed is True
 
@@ -360,6 +362,46 @@ def test_deploy_docs_raises_runtime_error_on_failure(tmp_path, monkeypatch):
         github_init.deploy_docs(tmp_path)
 
 
+def test_deploy_docs_passes_token_in_env(tmp_path, monkeypatch):
+    """With a token, deploy_docs injects the PAT into the subprocess env.
+
+    ``mkdocs gh-deploy`` shells out to ``git push`` itself, so the PAT is passed
+    as an ``http.extraheader`` ``Authorization: Basic`` header via
+    ``GIT_CONFIG_PARAMETERS`` (and the terminal prompt is disabled) rather than
+    being written to ``.git/config``.
+    """
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    github_init.deploy_docs(tmp_path, token="test")
+
+    env = captured["env"]
+    assert env is not None
+    expected_creds = base64.b64encode(b"x-access-token:test").decode()
+    assert env["GIT_CONFIG_PARAMETERS"] == f"'http.extraheader=Authorization: Basic {expected_creds}'"
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    # The existing environment is preserved alongside the injected entries.
+    assert "PATH" in env
+
+
+def test_deploy_docs_omits_env_without_token(tmp_path, monkeypatch):
+    """Without a token, deploy_docs passes no custom env (lets git auth itself)."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    github_init.deploy_docs(tmp_path)
+
+    assert captured["env"] is None
+
+
 def test_enable_pages_creates_site():
     """enable_pages POSTs the source config to the Pages endpoint."""
     client = GhInitClient.__new__(GhInitClient)
@@ -410,7 +452,7 @@ def test_init_repository_configures_pages_after_push(tmp_path, monkeypatch):
 
     result = init_repository(config, client)
 
-    deploy.assert_called_once_with(tmp_path)
+    deploy.assert_called_once_with(tmp_path, token=client.token)
     client.enable_pages.assert_called_once_with(repo, "gh-pages")
     client.set_homepage.assert_called_once_with(repo, "https://me.github.io/demo")
     assert result.pages_configured is True
@@ -727,6 +769,34 @@ def test_git_push_skips_commit_when_head_exists(tmp_path, monkeypatch):
     # `INITIAL_COMMIT_MESSAGE` doesn't trigger a false positive.
     assert not any("add" in c and "-A" in c for c in calls)
     assert not any("commit" in c for c in calls)
+
+
+def test_git_push_embeds_token_in_extraheader(tmp_path, monkeypatch):
+    """With a token, git_push authenticates the push via a one-shot http.extraheader.
+
+    The remote URL stays clean (no embedded creds, so the token never lands in
+    .git/config); the PAT is sent as an Authorization: Basic header through
+    `-c` on the push command itself.
+    """
+    calls = _record_calls(monkeypatch, head_exists=False)
+    git_push(tmp_path, "https://github.com/me/demo.git", branch="master", force=False, token="test")
+
+    expected_creds = base64.b64encode(b"x-access-token:test").decode()
+    push_calls = [" ".join(c) for c in calls if "push" in c]
+    assert any(f"http.extraheader=Authorization: Basic {expected_creds}" in c for c in push_calls)
+    # Remote is added against the clean URL (token not embedded).
+    assert any("remote add origin https://github.com/me/demo.git" in " ".join(c) for c in calls)
+    assert any(c.endswith("push -u origin master") for c in push_calls)
+
+
+def test_git_push_omits_extraheader_without_token(tmp_path, monkeypatch):
+    """Without a token, git_push pushes plainly (lets SSH / credential helpers work)."""
+    calls = _record_calls(monkeypatch, head_exists=False)
+    git_push(tmp_path, "git@github.com:me/demo.git", branch="master", force=False)
+
+    push_calls = [" ".join(c) for c in calls if "push" in c]
+    assert any(c.endswith("push -u origin master") for c in push_calls)
+    assert not any("extraheader" in c for c in push_calls)
 
 
 # Constant under test, kept local to avoid importing internal name into tests.


### PR DESCRIPTION
`git_push` ran `git push` against the repo's plain HTTPS clone URL under `capture_output=True`, so git had neither a TTY nor a credential helper and died with exit 128 ("could not read Username for 'https://github.com'") even though gh-init held a valid PAT it had just used to create the repo.

Inject the token as a one-shot `http.extraheader` `Authorization: Basic` header (`x-access-token:<token>`) on the push command so it authenticates non-interactively without the PAT ever being written to `.git/config`. Apply the same header via `GIT_CONFIG_PARAMETERS` to the `mkdocs gh-deploy` subprocess in `deploy_docs`, since gh-deploy shells out to its own `git push` to gh-pages.

The client exposes its token read-only so the orchestrator can feed it to both subprocess helpers.